### PR TITLE
Add github actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Test application
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox tox-gh-actions
+      - name: Test with tox
+        run: tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Test application
+name: Test
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ It will also install this package in development mode, so that code changes are 
   pytest --cov-report term-missing --cov=NEW_REPO
   ```
 
+- Continous integration is by default supported via [GitHub actions](https://help.github.com/en/actions). GitHub actions is free for public repos and comes with 2000 free Ubuntu build minutes per month for private repos.
+
 - To activate continuous integration testing on Travis CI, add a `.travis.yml` file with this contents to the repo.
 
   ```yaml

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,12 @@
 envlist = py36, py37, py38, lint
 skip_missing_interpreters = True
 
+[gh-actions]
+python =
+    3.6: py36, lint
+    3.7: py37
+    3.8: py38
+
 [travis]
 python =
   3.6: py36, lint


### PR DESCRIPTION
- Add github actions CI.
- Private repos have 2000 free build minutes on Ubuntu per month per user or organization account.

https://help.github.com/en/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions#about-billing-for-github-actions